### PR TITLE
Fixes CreateRelationAction on windows systems

### DIFF
--- a/src/Actions/Relation/CreateRelationAction.php
+++ b/src/Actions/Relation/CreateRelationAction.php
@@ -62,7 +62,7 @@ class CreateRelationAction
      */
     private function endOfClass($file)
     {
-        $lines = explode(PHP_EOL, file_get_contents($file));
+        $lines = preg_split('/\r\n|\r|\n/', file_get_contents($file));
         $lastOccurrence = null;
 
         foreach ($lines as $index => $line) {


### PR DESCRIPTION
Funny enough the PHP_EOL does work for creating newlines, but not for reading (on windows), that's why the other instances of PHP_EOL can stay. 