### PR TITLE
Add an extra field instead of saving the model in the create modal

### DIFF
--- a/resources/js/components/Modal/CreateModel.vue
+++ b/resources/js/components/Modal/CreateModel.vue
@@ -20,7 +20,7 @@
                         <div v-for="field in fields" :key="field.id" class="md:flex md:items-center">
                             <div class="md:w-1/3">
                                 <input
-                                    @keydown.enter="save()"
+                                    @keydown.enter="addField()"
                                     v-model="field.name"
                                     placeholder="Field name"
                                     class="field bg-white appearance-none border-2 border-gray-200 rounded w-full py-2 px-4 mr-4
@@ -39,7 +39,7 @@
                             <div class="md:w-2/3">
                                 <input
                                     v-model="field.type"
-                                    @keydown.enter="save()"
+                                    @keydown.enter="addField()"
                                     placeholder="Default: string|max:255"
                                     class="field bg-gray-200 appearance-none border-2 border-gray-200 rounded w-full py-2 px-4
                                     text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-purple-500"


### PR DESCRIPTION
Personally, I've pressed enter way too many times already while playing around and accidentally saved the model unintentionally. It feels very natural (I dare to say for most users) to create new rows by pressing enter.