### PR TITLE
fix typo in artisan install command

### DIFF
--- a/src/Console/Commands/Install.php
+++ b/src/Console/Commands/Install.php
@@ -19,7 +19,7 @@ class Install extends Command
      *
      * @var string
      */
-    protected $description = 'Install\'s laravel-schematics package';
+    protected $description = 'Installs laravel-schematics package';
 
     /**
      * Execute the console command.


### PR DESCRIPTION
This change fixes a small typo in the artisan install command. 
