### PR TITLE
Fixed exception when creating a resource controller

### DIFF
--- a/src/Actions/Resource/CreateResourceControllerAction.php
+++ b/src/Actions/Resource/CreateResourceControllerAction.php
@@ -19,6 +19,7 @@ class CreateResourceControllerAction
             'name' => $name,
             '--resource' => true,
             '--model' => config('schematics.model.namespace').$model,
+            '-q',
         ]);
 
         return Artisan::output();

--- a/src/Actions/Resource/CreateResourceControllerAction.php
+++ b/src/Actions/Resource/CreateResourceControllerAction.php
@@ -19,7 +19,7 @@ class CreateResourceControllerAction
             'name' => $name,
             '--resource' => true,
             '--model' => config('schematics.model.namespace').$model,
-            '-q',
+            '--quiet',
         ]);
 
         return Artisan::output();


### PR DESCRIPTION
On PHP 7.4 - Laravel 7.2 I got an STDIN constant exception when creating a ResourceController. Since we are not running this in a console, we can't give input anyway. So I would suggest to add this to all Artisan::call() calls in the "make:" namespace.

Exeption:

`message: "Use of undefined constant STDIN - assumed 'STDIN' (this will throw an Error in a future version of PHP)"`
`exception: "ErrorException"`
`file: "vendor/symfony/console/Helper/QuestionHelper.php"`
`line: 118`