### PR TITLE
WIP: pivot table

### DIFF
--- a/config/schematics.php
+++ b/config/schematics.php
@@ -47,5 +47,7 @@ return [
 
     'delete' => [
         'migration' => false,
-    ],
+	],
+	
+	'use-pivot' => true,
 ];

--- a/resources/js/components/Modal/CreateModel.vue
+++ b/resources/js/components/Modal/CreateModel.vue
@@ -56,6 +56,113 @@
                     </transition-group>
                 </draggable>
 
+
+				<span v-if="pivot.isPivotModel && config('use-pivot')">	
+					<hr 
+					class="w-full my-4"
+					/>
+					<div class="md:flex md:items-center">
+						<div>
+							<input
+								v-model="pivot.source"
+								placeholder="Existing source model"
+								class="field bg-white appearance-none border-2 border-gray-200 rounded w-full py-2 px-4 mr-4
+									text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-purple-500"
+
+								type="text"
+							>
+						</div>
+
+						<div>
+							<input
+								v-model="pivot.target"
+								placeholder="Existing target model"
+								class="field bg-white appearance-none border-2 border-gray-200 rounded w-full py-2 px-4 mr-4
+									text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-purple-500"
+
+								type="text"
+							>
+						</div>
+					</div>
+						<div class="md:flex md:items-center">
+						<div>
+							<input
+								v-model="pivot.methods.first"
+								placeholder="Method"
+								class="field bg-white appearance-none border-2 border-gray-200 rounded w-full py-2 px-4 mr-4
+									text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-purple-500"
+
+								type="text"
+							>
+						</div>
+
+						<div>
+							<input
+								v-model="pivot.methods.second"
+								placeholder="Method"
+								class="field bg-white appearance-none border-2 border-gray-200 rounded w-full py-2 px-4 mr-4
+									text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-purple-500"
+
+								type="text"
+							>
+						</div>
+					</div>
+
+
+					<div class="md:flex md:items-center">
+						<div>
+							<input
+								v-model="pivot.foreignKeys.first"
+								placeholder="Foreign key"
+								class="field bg-white appearance-none border-2 border-gray-200 rounded w-full py-2 px-4 mr-4
+									text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-purple-500"
+
+								type="text"
+							>
+						</div>
+
+						<div>
+							<input
+								v-model="pivot.foreignKeys.second"
+								placeholder="Foreign key"
+								class="field bg-white appearance-none border-2 border-gray-200 rounded w-full py-2 px-4 mr-4
+									text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-purple-500"
+
+								type="text"
+							>
+						</div>
+					</div>
+					<div class="md:flex md:items-center">
+						
+						<div>
+							<input
+								v-model="pivot.localKeys.first"
+								placeholder="References"
+								class="field bg-white appearance-none border-2 border-gray-200 rounded w-full py-2 px-4 mr-4
+									text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-purple-500"
+
+								type="text"
+							>
+						</div>
+
+						<div>
+							<input
+								v-model="pivot.localKeys.second"
+								placeholder="References"
+								class="field bg-white appearance-none border-2 border-gray-200 rounded w-full py-2 px-4 mr-4
+									text-gray-700 leading-tight focus:outline-none focus:bg-white focus:border-purple-500"
+
+								type="text"
+							>
+						</div>
+
+						
+
+						<i style="cursor:move"
+							class="fas fa-arrows-alt-v text-gray-200 mx-1"/>
+					</div>
+				</span>
+
                 <div class="flex text-lg mt-3 items-end outline-none">
                     <div class="inline-block w-full relative bg-transparent mx-5 mb-10 pt-2 pl-5">
                         <span class="plus-minus">
@@ -80,6 +187,7 @@
                             </button>
                         </span>
 
+
                         <div class="md:flex md:items-center">
                             <label class="block text-gray-500 font-bold">
                                 <input
@@ -101,7 +209,7 @@
                             </label>
                         </div>
 
-                        <div class="md:flex md:items-center">
+                        <div class="md:flex md:items-center" v-if="!pivot.isPivotModel">
                             <label class="block text-gray-500 font-bold">
                                 <input
                                     v-model="actions.hasResourceController"
@@ -112,13 +220,24 @@
                             </label>
                         </div>
 
-                        <div class="md:flex md:items-center">
+                        <div class="md:flex md:items-center" v-if="!pivot.isPivotModel">
                             <label class="block text-gray-500 font-bold">
                                 <input
                                     v-model="actions.hasFormRequest"
                                     class="mr-2 leading-tight" type="checkbox">
                                 <span class="text-sm w-2/3">
                                     Form Request
+                                </span>
+                            </label>
+                        </div>
+
+						<div vif="this.config('use-pivot')" class="md:flex md:items-center">
+                            <label class="block text-gray-500 font-bold">
+                                <input
+                                    v-model="pivot.isPivotModel"
+                                    class="mr-2 leading-tight" type="checkbox">
+                                <span class="text-sm w-2/3">
+                                    Pivot Model
                                 </span>
                             </label>
                         </div>
@@ -164,29 +283,53 @@
                 actions: {
                     hasModelMigration: this.config('create.migration'),
                     hasFormRequest: this.config('create.form-request'),
-                    hasResourceController: this.config('create.resource-controller'),
+					hasResourceController: this.config('create.resource-controller'),
+					hasPivotRelations : false,
                 },
                 options: {
-                    hasTimestamps: false,
+					hasTimestamps: false,
                 },
                 fields: [{
                     id: this.uuid(),
                     name: '',
                     type: '',
                     error: false
-                }]
+				}],
+				pivot: {
+					isPivotModel: false,
+					source : null,
+					target: null,
+					localKeys :{
+						first : null,
+						second: null,
+					},
+					foreignKeys :{
+						first : null,
+						second: null,
+					},
+					methods :{
+						first : null,
+						second: null,
+					}
+				}
             }
         },
 
         created() {
-            EventBus.$on('new-model', () => {
-                this.fields = [{
-                    id: this.uuid(),
-                    name: '',
-                    type: '',
-                    error: false
-                }];
-            });
+            EventBus.$on('new-model', data => {
+				this.pivot.isPivotModel = !! data && data.isPivotModel;
+				
+				if (!this.pivot.isPivotModel){
+					this.fields = [{
+						id: this.uuid(),
+						name: '',
+						type: '',
+						error: false
+					}];
+				} else {
+					this.fields = [];
+				}
+			});
         },
 
         mounted() {
@@ -217,7 +360,7 @@
             },
 
             removeField(field = null) {
-                if (this.fields.length > 1) {
+				if (this.fields.length > 1) {
                     this.fields.splice(field ? this.fields.indexOf(field) : -1, 1);
                 }
             },
@@ -231,7 +374,7 @@
                 fieldErrors.forEach(field => field.error = true);
 
                 return !fieldErrors.length;
-            },
+			},
 
             validName(name) {
                 return /^[A-Za-z]+$/.test(name)
@@ -248,17 +391,18 @@
                     .toggleClass('focus:border-red-500 border-red-500', !this.validName(name));
 
                 if (!this.validName(name) || !this.validFields()) return;
-
-                EventBus.$emit('modal-close');
+				
+				EventBus.$emit('modal-close');
                 EventBus.$emit('loading', true);
-
-                $.post('schematics/models/create', {
+				
+				$.post('schematics/models/create', {
                     'name': name,
-                    'fields': this.fields,
-                    'actions': this.actions,
-                    'options': this.options,
+                    'fields': this.fields.length ? this.fields : [''], 
+					'pivot' : this.pivot,
+					'actions': this.actions,
+					'options': this.options,
                 }, () => {
-                    location.reload();
+					location.reload();
                 }).fail((e) => {
                     console.error(e);
 
@@ -275,7 +419,12 @@
                         this.options.hasTimestamps = false;
                     }
                 }
-            }
+            },
+			'pivot.isPivotModel' :{
+				handler(newValue, oldValue){
+					this.actions.hasPivotRelations = newValue;
+				}
+			}
         }
     }
 </script>

--- a/resources/js/components/Modal/Relation.vue
+++ b/resources/js/components/Modal/Relation.vue
@@ -99,19 +99,25 @@
             remove() {
                 EventBus.$emit('loading', true);
                 EventBus.$emit('modal-close');
-
-                this.relation.actions = this.actions;
-
+				this.relation.actions = this.actions;
                 $.post('schematics/relations/delete', this.relation, () => {
-                    Schematics.relations[this.relation.table]
-                        .splice(
-                            Schematics.relations[this.relation.table]
-                                .findIndex(r => r.method.name === this.relation.method.name)
-                            , 1);
+					if (this.config('use-pivot') && this.relation.type == 'belongsToMany'){
+						//When pivot relation is made, force refresh, because FE state is out of sync with BE
+						//TODO: Would be more consistent to fix in FE...
+						setTimeout(() => {
+							location.reload();
+						}, 1);
+					} else {
+						Schematics.relations[this.relation.table]
+							.splice(
+								Schematics.relations[this.relation.table]
+									.findIndex(r => r.method.name === this.relation.method.name)
+								, 1);
 
-                    EventBus.$emit('loading', false);
-                    EventBus.$emit('plumb');
-                    setTimeout(Schematics.refresh, 1);
+						EventBus.$emit('loading', false);
+						EventBus.$emit('plumb');
+						setTimeout(Schematics.refresh, 1);
+					}
                 }).fail((e) => {
                     console.error(e);
 

--- a/resources/js/lib/Plumbing.js
+++ b/resources/js/lib/Plumbing.js
@@ -91,7 +91,7 @@ export default {
                             $target = $(`#${relation.relation.table}:visible`);
 
                         if ($source.length && $target.length) {
-                            jsPlumb.connect({
+							jsPlumb.connect({
                                 source: $source,
                                 target: $target,
                                 newConnection: false,
@@ -105,7 +105,11 @@ export default {
                                     ['Arrow', {location: 0.2, width: 10, length: 10}],
                                     ['Label', {
                                         cssClass: `relation rel-${table}-${index}`,
-                                        label: `<i class='fas icon fa-link'></i> <b>${relation.method.name}():</b> ${relation.type}`,
+										label: `<i class='fas icon fa-link'></i> <b>
+											${relation.relation.pivotsFrom ? relation.relation.pivotsFrom  + " ::": ""}
+											${relation.method.name}():</b> ${relation.type}
+											${relation.relation.pivotsTo ? " (through pivot)" : ""}
+										`,
                                         location: 0.4
                                     }]
                                 ],
@@ -178,8 +182,13 @@ export default {
         },
 
         openRelationModal(relation) {
-            relation.model = `${relation.model}`.split('\\').slice(-1)[0];
-            relation.type = relation.type.charAt(0).toLowerCase() + relation.type.slice(1);
+			if (this.config('use-pivot') && relation.relation.pivotsFrom){
+            	relation.model = `${relation.relation.pivotsFrom}`.split('\\').slice(-1)[0];
+			} else {
+            	relation.model = `${relation.model}`.split('\\').slice(-1)[0];
+			}
+
+			relation.type = relation.type.charAt(0).toLowerCase() + relation.type.slice(1);
 
             EventBus.$emit(
                 'modal-open',

--- a/resources/stubs/migration/relation.stub
+++ b/resources/stubs/migration/relation.stub
@@ -25,7 +25,7 @@ class $classname$ extends Migration
      */
     public function up()
     {
-        Schema::table('$source$', static function (Blueprint $table) {
+        Schema::table('$table$', static function (Blueprint $table) {
             $column$
         });
     }
@@ -37,7 +37,7 @@ class $classname$ extends Migration
      */
     public function down()
     {
-        Schema::table('$source$', static function (Blueprint $table) {
+        Schema::table('$table$', static function (Blueprint $table) {
             $table->dropForeign(['$foreignKey$']);
         });
     }

--- a/resources/stubs/model.stub
+++ b/resources/stubs/model.stub
@@ -6,6 +6,8 @@ use Illuminate\Database\Eloquent\Model;
 
 class $model$ extends Model
 {
+
+    $tableAttributeLine$
     /**
      * The attributes that are mass assignable.
      *

--- a/resources/stubs/relation.stub
+++ b/resources/stubs/relation.stub
@@ -1,7 +1,8 @@
     /**
      * @return \Illuminate\Database\Eloquent\Relations\$class$
+	 * $tags$
      */
     public function $method$()
     {
-        return $this->$type$($target$$keys$);
+        return $this->$type$($params$);
     }

--- a/src/Actions/Migration/CreateModelMigrationAction.php
+++ b/src/Actions/Migration/CreateModelMigrationAction.php
@@ -7,6 +7,7 @@ use Illuminate\Support\Facades\File;
 use Mtolhuys\LaravelSchematics\Services\RuleParser;
 use Mtolhuys\LaravelSchematics\Actions\Migration\Traits\CreatesMigrations;
 use Mtolhuys\LaravelSchematics\Services\StubWriter;
+use Config;
 
 class CreateModelMigrationAction
 {
@@ -17,15 +18,18 @@ class CreateModelMigrationAction
      */
     public function execute($request)
     {
-        $model = ucfirst($request['name']);
-        $table = Str::plural(Str::snake($model));
+		$model = ucfirst($request['name']);
+		
+		$singularTableName = $request['pivot']['isPivotModel'] == 'true'&& $request['pivot']['isPivotModel'] == 'true';
+		$table = $singularTableName ? Str::snake($model) : Str::plural(Str::snake($model));
+
         $stub = __DIR__ . '/../../../resources/stubs/migration/model.stub';
         $this->filename = 'database/migrations/'
             . date('Y_m_d_His')
             . "_create_{$table}_table.php";
 
         (new StubWriter(base_path($this->filename), $stub))->write([
-            '$classname$' => 'Create' . Str::plural($model) . 'Table',
+            '$classname$' => 'Create' . ($singularTableName ? $model : Str::plural($model)) . 'Table',
             '$columns$' => rtrim($this->getColumns($request)),
             '$table$' => $table,
         ]);

--- a/src/Actions/Migration/CreateRelationMigrationAction.php
+++ b/src/Actions/Migration/CreateRelationMigrationAction.php
@@ -6,6 +6,8 @@ use Illuminate\Support\Str;
 use Illuminate\Support\Facades\File;
 use Mtolhuys\LaravelSchematics\Actions\Migration\Traits\CreatesMigrations;
 use Mtolhuys\LaravelSchematics\Services\StubWriter;
+use Illuminate\Http\Response;
+use Config;
 
 class CreateRelationMigrationAction
 {
@@ -17,20 +19,33 @@ class CreateRelationMigrationAction
      */
     public function execute($request)
     {
-        $source = app($request['source'])->getTable();
-        $target = app($request['target'])->getTable();
-        $foreignKey = $this->getForeignKey($request);
-        $stub = __DIR__ . '/../../../resources/stubs/migration/relation.stub';
-        $this->filename = 'database/migrations/'
-            . date('Y_m_d_His')
-            . "_create_{$source}_{$target}_relation.php";
-
-        (new StubWriter(base_path($this->filename), $stub))->write([
-            '$column$' => "\$table->foreign('$foreignKey')->references('{$this->getLocalKey($request)}')->on('$target');",
-            '$classname$' => 'Create' . ucfirst(Str::camel($source)) . ucfirst(Str::camel($target)) . 'Relation',
-            '$foreignKey$' => $foreignKey,
-            '$source$' => $source,
-            '$target$' => $target,
-        ]);
+		$target = app($request['target'])->getTable();
+		$foreignKey = $this->getForeignKey($request);
+		$localKey = $this->getLocalKey($request);
+		$source = app($request['source'])->getTable();
+		if (Config::get('schematics.use-pivot') && $request['type'] == 'BelongsToMany'){
+			$secondForeignKey = $this->getSecondForeignKey($request);
+			$secondLocalKey = $this->getSecondLocalKey($request);
+			
+			$column = "\$table->foreign('$foreignKey')->references('$localKey')->on('$target');" . PHP_EOL .
+			"            \$table->foreign('$secondForeignKey')->references('$secondLocalKey')->on('$source');";
+			$table = app($request['pivot'])->getTable();
+		} else{
+			$column = "\$table->foreign('$foreignKey')->references('{$this->getLocalKey($request)}')->on('$target');";
+			$table = $source;
+		}
+		$this->filename = 'database/migrations/'
+		. date('Y_m_d_His')
+		. "_create_{$source}_{$target}_relation.php";
+		$stub = __DIR__ . '/../../../resources/stubs/migration/relation.stub';
+			
+		(new StubWriter(base_path($this->filename), $stub))->write([
+			'$classname$' => 'Create' . ucfirst(Str::camel($source)) . ucfirst(Str::camel($target)) . 'Relation',
+			'$foreignKey$' => $foreignKey,
+			'$table$' => $table,
+			'$target$' => $target,
+			'$column$' => $column,
+		]);
+		
     }
 }

--- a/src/Actions/Migration/Traits/CreatesMigrations.php
+++ b/src/Actions/Migration/Traits/CreatesMigrations.php
@@ -56,7 +56,26 @@ trait CreatesMigrations
                 )
             )
             : $request['method']['foreignKey'];
-    }
+	}
+	
+	protected function getSecondLocalKey($request): string
+    {
+        return empty($request['method']['secondLocalKey'])
+            ? 'id' : $request['method']['secondLocalKey'];
+	}
+
+    protected function getSecondForeignKey($request): string
+    {
+        return empty($request['method']['secondForeignKey'])
+            ? strtolower(
+                Str::snake(
+                    substr(strrchr($request['source'], "\\"), 1) . '_id'
+                )
+            )
+            : $request['method']['secondForeignKey'];
+	}
+	
+
 
     /**
      * @param $fields

--- a/src/Actions/Model/CreateModelAction.php
+++ b/src/Actions/Model/CreateModelAction.php
@@ -3,6 +3,8 @@
 namespace Mtolhuys\LaravelSchematics\Actions\Model;
 
 use Mtolhuys\LaravelSchematics\Services\StubWriter;
+use Illuminate\Support\Str;
+use Config;
 
 class CreateModelAction
 {
@@ -12,14 +14,18 @@ class CreateModelAction
      */
     public function execute($request)
     {
-        $name = $request['name'];
+		$name = $request['name'];
+		$singularTableName = Config::get('schematics.use-pivot') && $request['pivot']['isPivotModel'] == 'true';
         $stub = __DIR__ . '/../../../resources/stubs/model.stub';
         $file = config('schematics.model.path') . "/{$name}.php";
-
+		
         (new StubWriter($file, $stub))->write([
             '$fillables$' => $this->getFillables($request['fields']),
             '$namespace$' => rtrim(config('schematics.model.namespace'), '\\'),
-            '$model$' => $name,
+			'$model$' => $name,
+			'$tableAttributeLine$' => $singularTableName ? 
+				'protected $table = "' . Str::snake($name = $request['name']) . '";'
+				: '',
         ]);
     }
 

--- a/src/Actions/Relation/CreatePivotRelationsAction.php
+++ b/src/Actions/Relation/CreatePivotRelationsAction.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Mtolhuys\LaravelSchematics\Actions\Relation;
+
+use ReflectionClass;
+use Config;
+
+use Mtolhuys\LaravelSchematics\Actions\Relation\CreateRelationAction;
+
+class CreatePivotRelationsAction extends CreateRelationAction
+{
+    public function execute($request)
+    {		
+        $stub = __DIR__ . '/../../../resources/stubs/relation.stub';
+		
+		$this->createRelation(
+			$stub, 
+			$request['pivot']['source'], 
+			$request['pivot']['target'],
+			" , '" . $request['pivot']['foreignKeys']['second'] . "' , '" . $request['pivot']['foreignKeys']['first'] . "'",	
+			$request['pivot']['methods']['first'],
+			'BelongsToMany',
+			Config::get('schematics.model.namespace') . $request['name']
+		);
+
+		$this->createRelation(
+			$stub, 
+			$request['pivot']['target'], 
+			$request['pivot']['source'],
+			" , '" . $request['pivot']['foreignKeys']['first'] . "' , '" . $request['pivot']['foreignKeys']['second'] . "'",	
+			$request['pivot']['methods']['second'],
+			'BelongsToMany',
+			Config::get('schematics.model.namespace') . $request['name']
+		);
+	}
+	
+	//TODO: should be place in parent so it can also be used there
+	private function createRelation($stub, $source, $target, $keys, $methodName, $type, $pivotModelName = null)
+	{
+		$file = (new ReflectionClass($source))->getFileName();
+        $lines = file($file, FILE_IGNORE_NEW_LINES);
+		$injectionLine = $this->endOfClass($file) - 1;
+		$pivotTable = App($pivotModelName)->getTable();
+		$generateMethodParams = [
+			'type' => $type,
+			'source' => $source,
+			'target' => $target,
+			'keys'=> $keys,
+			'method' => ['name' => $methodName],
+			'pivot' => $pivotModelName,
+		];
+        $lines[$injectionLine] = PHP_EOL . $this->generateMethod($generateMethodParams, $stub) . '}';
+		file_put_contents($file, implode("\n", $lines));
+	}
+}

--- a/src/Exceptions/PivotException.php
+++ b/src/Exceptions/PivotException.php
@@ -1,0 +1,9 @@
+<?php
+namespace Mtolhuys\LaravelSchematics\Exceptions;
+
+class PivotException extends \Exception
+{
+    public function __construct($message, $code = 0, Exception $previous = null) {
+        parent::__construct($message);
+    }
+}

--- a/src/Http/Controllers/RelationsController.php
+++ b/src/Http/Controllers/RelationsController.php
@@ -7,11 +7,14 @@ use Mtolhuys\LaravelSchematics\Actions\Relation\DeleteRelationAction;
 use Mtolhuys\LaravelSchematics\Actions\Relation\CreateRelationAction;
 use Mtolhuys\LaravelSchematics\Http\Requests\CreateRelationRequest;
 use Mtolhuys\LaravelSchematics\Http\Requests\DeleteRelationRequest;
+use Mtolhuys\LaravelSchematics\Services\Pivot as PivotService;
+use Mtolhuys\LaravelSchematics\Exceptions\PivotException;
 use Illuminate\Contracts\Routing\ResponseFactory;
 use Symfony\Component\HttpFoundation\Response;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Routing\Controller;
 use ReflectionException;
+use Config;
 
 class RelationsController extends Controller
 {
@@ -24,9 +27,18 @@ class RelationsController extends Controller
      */
     public function create(CreateRelationRequest $request)
     {
-        $result = (new CreateRelationAction())->execute($request);
+		$input = $request->input();
+		if (Config::get('schematics.use-pivot')
+		&& $request['type'] == 'BelongsToMany') {
+			try{
+				$input['pivot'] = PivotService::GetPivotModelFromRequest($request);
+			} catch(PivotException $e){
+				return Response($e->getMessage(), 422);
+			}
+		}
+        $result = (new CreateRelationAction())->execute($input);
 
-        $this->optionalActions($request);
+        $this->optionalActions($input);
 
         Cache::forget('schematics');
 

--- a/src/Http/Controllers/SchematicsController.php
+++ b/src/Http/Controllers/SchematicsController.php
@@ -14,6 +14,7 @@ use Illuminate\Routing\Controller;
 use Illuminate\Support\Facades\DB;
 use Illuminate\View\View;
 use ReflectionException;
+use Config;
 
 class SchematicsController extends Controller
 {
@@ -84,8 +85,8 @@ class SchematicsController extends Controller
         $data = [
             'models' => $models,
             'relations' => RelationMapper::map($models),
-            'migrations' => $this->migrations(),
-        ];
+			'migrations' => $this->migrations(),
+		];
 
         Cache::put('schematics', $data, 1440);
 

--- a/src/Http/Controllers/Traits/HasOptionalActions.php
+++ b/src/Http/Controllers/Traits/HasOptionalActions.php
@@ -8,6 +8,7 @@ use Mtolhuys\LaravelSchematics\Actions\Migration\CreateRelationMigrationAction;
 use Mtolhuys\LaravelSchematics\Actions\Migration\DeleteMigrationAction;
 use Mtolhuys\LaravelSchematics\Actions\Resource\CreateFormRequestAction;
 use Mtolhuys\LaravelSchematics\Actions\Resource\CreateResourceControllerAction;
+use Mtolhuys\LaravelSchematics\Actions\Relation\CreatePivotRelationsAction;
 
 trait HasOptionalActions
 {
@@ -39,7 +40,8 @@ trait HasOptionalActions
             'hasColumnsMigration' => new CreateColumnsMigrationAction,
             'hasModelMigration' => new CreateModelMigrationAction,
             'deletesMigration' => new DeleteMigrationAction,
-            'hasFormRequest' => new CreateFormRequestAction,
+			'hasFormRequest' => new CreateFormRequestAction,
+			'hasPivotRelations' => new CreatePivotRelationsAction,
         ][$option];
     }
 }

--- a/src/Services/Pivot.php
+++ b/src/Services/Pivot.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Mtolhuys\LaravelSchematics\Services;
+
+use ReflectionClass;
+use Mtolhuys\LaravelSchematics\Http\Requests\CreateRelationRequest;
+use Mtolhuys\LaravelSchematics\Exceptions\PivotException;
+
+class Pivot
+{
+	/**
+	 * Find pivot model class for BelongsToMany
+	 * 
+	 * @return object|null Returns instance of pivot model when found, null on failure
+	 */
+	public static function getPivotModel($method)
+	{
+		$pattern = '/(@schematics-pivot)([\s]*)([\S]*)/';
+		preg_match_all($pattern, $method->getDocComment(), $matches);
+		if (isset($matches[1][0]) && $matches[1][0] == "@schematics-pivot"){
+			try{
+				$pivotModelName = $matches[3][0];
+			} catch (\Exception $e){
+				throw new PivotException("Malformed @schematics-pivot tag");
+			}
+			if (class_exists($pivotModelName)){
+				return App($pivotModelName);
+			} 
+		}
+		return NULL;
+	}
+
+	/**
+	 * Makes an attemp at finding pivot model class for BelongsToMany without @schematics-pivot tag
+	 * 
+	 * @return object|null Returns instance of pivot model when found, null on failure
+	 */
+	public static function getPivotModelFallback($srcModel, $invocation, $method, $models)
+	{
+
+		//Assumed name is ModeloneModeltwo or modeltwoModelone in same namespace, if not, we have to do dark magic
+		$reflectionOne =  new ReflectionClass($srcModel);
+		$reflectionTwo = new ReflectionClass($invocation->getRelated());
+
+		$possibleNames = [];
+		$assumedNamespace = $reflectionTwo->getNamespaceName();
+		$possibleNames[] = $assumedNamespace . '\\' . $reflectionOne->getShortName() . $reflectionTwo->getShortName();
+		$possibleNames[] = $assumedNamespace . '\\' . $reflectionTwo->getShortName() . $reflectionOne->getShortName();
+
+		$obj = NULL;
+		$i = 0;
+		for ($i = 0; $i < count($possibleNames); $i++){
+			if (class_exists($possibleNames[$i])){
+				$obj = app($possibleNames[$i]);
+				break;
+			}
+		};
+		if ($obj){
+			return $obj;
+		}
+
+		//Did not find it the easy way, analyze code to see if we get better results in some sort of desperate attempt
+		$source = file($method->getFileName());
+		$startLine = $method->getStartLine();
+		$endLine = $method->getEndLine();
+		$nLines = $endLine - $startLine;
+		$functionSrc = implode("", array_slice($source, $startLine, $nLines));
+
+		//this only works for very simple setups, if database name is given ( $this->belongsToMany('App\A', a_b);)
+		//TODO: deal more complex code ? ;_; simple regex wont help there, but is probably overkill anyway
+		$pattern = '/(belongsToMany\()([\s\S]*)(,)([\s\S]*)(\))/';
+		preg_match_all($pattern, $functionSrc, $matches);
+		if (!isset($matches[4][0])){
+			return NULL;
+		}
+	
+		//Won't scale amazing with big databases
+		foreach ($models as $model){
+			$obj = app($model);
+			if ("assumedSecondParam" == $obj->getTable()){
+				break;
+			}
+		}
+		return $obj;
+	}
+
+	/**
+	 * @param CreateRelationRequest $request 
+	 * @return string Name of pivot model
+	 * @throws PivotException When pivot model does not exist.
+	 */
+	public static function GetPivotModelFromRequest(CreateRelationRequest $request)
+	{
+		if (!isset($request['pivot']) || !$request['pivot']){
+			$name  = self::getDefaultPivotModelName($request['source'], $request['target']);
+		} else {
+			$name = $request['pivot'];
+		}
+		return $name;
+	}
+
+	/**
+	 * Returns default modelName (including namespace) for a pivot model, based on name of target and source models.
+	 * Throws exception if model with default name does not exist, so returned name is always valid class.
+	 * 
+	 * @param string $sourceModelName Name of source model including namespace
+	 * @param string $targetModelName Name of target model including namespace
+	 * @return string Name of pivot model
+	 * @throws PivotException When model with default name does not exist.
+	 */
+	private static function getDefaultPivotModelName(string $sourceModelName,string $targetModelName)
+	{
+		$arr = explode('\\', $sourceModelName);
+		$source = end($arr);
+		$namespaceName = count($arr) > 1 ? $arr[0] : "";
+
+		$arr = explode('\\', $targetModelName);
+		$target = end($arr);
+
+		$modelName = $namespaceName . '\\' . $target . $source;
+
+		if (!class_exists($modelName)){
+			$modelName = $namespaceName . '\\' . $source . $target;
+			if (!class_exists($modelName)){
+				throw new  PivotException("Pivot model with default name does not exist");
+			}
+		}	
+		return $modelName;
+	}
+}

--- a/src/Services/RelationMapper.php
+++ b/src/Services/RelationMapper.php
@@ -1,16 +1,20 @@
 <?php
 
 namespace Mtolhuys\LaravelSchematics\Services;
+use Mtolhuys\LaravelSchematics\Services\Pivot as PivotService;
 
 use Illuminate\Database\Eloquent\Relations\Relation;
+use Illuminate\Database\Eloquent\Model;
 
 use ReflectionException;
 use ReflectionClass;
 use ReflectionMethod;
+use Config;
 
 class RelationMapper extends ClassReader
 {
-    public static $relations = [];
+	public static $relations = [];
+	public static $models = [];
 
     /**
      * Maps relations details map through array of Eloquent models
@@ -21,22 +25,28 @@ class RelationMapper extends ClassReader
      */
     public static function map($models = null): array
     {
-        $models = $models ?? ModelMapper::map();
-
+		$models = $models ?? ModelMapper::map();
+		self::$models = $models;
         foreach ($models as $model) {
             self::getMethods($model)->each(static function ($method) use ($model) {
-                $details = self::getDetails($method, $model);
-
-                if ($details) {
-                    if (empty(self::$relations[$details->table])) {
-                        self::$relations[$details->table] = [];
-                    }
-
-                    self::$relations[$details->table][] = $details;
+				$details = self::getDetails($method, $model);
+				if ($details) {
+					if (empty(self::$relations[$details->table])) {
+						self::$relations[$details->table] = [];
+					}
+					self::$relations[$details->table][] = $details;
+					
+					$usePivot = Config::get('schematics.use-pivot');
+					if ($usePivot && $details->type == "BelongsToMany" && isset($details->pivotsTo)){
+						if (empty(self::$relations[$details->relation->table])) {
+							self::$relations[$details->relation->table] = [];
+						}
+						self::$relations[$details->relation->table][] = $details->pivotsTo;
+						unset( $details->pivotsTo);
+					}
                 }
             });
         }
-
         return self::$relations;
     }
 
@@ -47,32 +57,79 @@ class RelationMapper extends ClassReader
      */
     protected static function getDetails(ReflectionMethod $method, string $model)
     {
+		$usePivot = Config::get('schematics.use-pivot');
         try {
             $class = app($model);
             $invocation = $method->invoke($class);
 
             if ($invocation instanceof Relation) {
-                $related = $invocation->getRelated();
+				if ($usePivot && get_class($invocation) === "Illuminate\Database\Eloquent\Relations\BelongsToMany"){
+					$pivotModel = PivotService::getPivotModel($method);
+					if (!$pivotModel){
+						$pivotModel = PivotService::getPivotModelFallback($class, $invocation, $method, self::$models);
+					}
+					if ($pivotModel){
+						$dst = $invocation->getRelated();
+						//TODO: neater way to create these objects
+						$result = (object)[
+							'model' => $model,
+							'table' =>  $class->getTable(),
+							'type' => 'BelongsToMany',
 
-                return (object)[
-                    'model' => $model,
-                    'table' => $class->getTable(),
-                    'type' => (new ReflectionClass($invocation))->getShortName(),
-                    'relation' => (object)[
-                        'model' => get_class($related),
-                        'table' => $related->getTable(),
-                    ],
-                    'method' => (object)[
-                        'name' => $method->getName(),
-                        'file' => $method->getFileName(),
-                        'line' => $method->getStartLine(),
-                    ],
-                ];
+							'relation' => (object)[
+								'model' => get_class($pivotModel),
+								'table' => $pivotModel->getTable(),
+								'pivotsTo' => get_class($dst),
+							],
+							'method' => (object)[
+								'name' => $method->getName(),
+								'file' => $method->getFileName(),
+								'line' => $method->getStartLine(),
+							],
+						];
+						$pivotsTo = (object)[
+							'model' => $model,
+							'table' =>  $class->getTable(),
+							'type' => 'BelongsToMany',
+
+							'relation' => (object)[
+								'model' => get_class($dst),
+								'table' => $dst->getTable(),
+								'pivotsFrom' => $model
+							],
+							'method' => (object)[
+								'model' => $model, //To make it clear in GUI that function does not come from pivot model, this should be shown in GUI
+								'name' => $method->getName(),
+								'file' => $method->getFileName(),
+								'line' => $method->getStartLine(),
+							],
+						];
+						$result->pivotsTo = $pivotsTo;
+					} else {
+						return NULL;
+					}
+				} else {
+					$related = $invocation->getRelated();
+					$result = (object)[
+						'model' => $model,
+						'table' => $class->getTable(),
+						'type' => (new ReflectionClass($invocation))->getShortName(),
+						'relation' => (object)[
+							'model' => get_class($related),
+							'table' => $related->getTable(),
+						],
+						'method' => (object)[
+							'name' => $method->getName(),
+							'file' => $method->getFileName(),
+							'line' => $method->getStartLine(),
+						],
+					];
+				}	
+				return $result;
             }
-        }
+		}
         catch (\Throwable $e) {
             return null;
         }
-    }
-
+	}
 }


### PR DESCRIPTION
Work in progress. Some things that need to be done from top of my head:

- FE should check model exists.
- When pivot model fields are left empty, should use default.
- BelongsToMany relations are now 'pseudo-relations' in backend (A related to AB, AB related to A).
Maybe would be better if these 'pseudo-relations' exist in frontend only, because they are only there for visuals, and aren't actual model relations. They are not stored though (outside of cache) so maybe it's fine this way.
- Migrations for relations when generating pivot model with relations.
- General clean, not all parts are 'equally elegant'. Also some TODOs can be found in the wild
- I *think* belongsToManyMigrations dont delete correctly when the checkbox is used

