### PR TITLE
namespace fix

### DIFF
--- a/src/Services/ModelMapper.php
+++ b/src/Services/ModelMapper.php
@@ -20,6 +20,7 @@ class ModelMapper extends ClassReader
     public static function map(): array
     {
         $paths = config('schematics.model.paths', [app_path()]);
+        $namespace = config('schematics.model.namespace', 'App\\');
 
         foreach ($paths as $path) {
             $files = new RecursiveIteratorIterator(
@@ -30,8 +31,8 @@ class ModelMapper extends ClassReader
                 if (self::readablePhp($file)) {
                     $class = self::getClassName($file);
 
-                    if (is_subclass_of($class, Model::class)) {
-                        self::$models[] = $class;
+                    if (is_subclass_of($namespace . $class, Model::class)) {
+                        self::$models[] = $namespace . $class;
                     }
                 }
             }


### PR DESCRIPTION
As mentioned in issue number #52, when you have a different namespace for models than App\xxx, the package can't find them.
So I've added a namespace in ModelMapper which solves the issue.